### PR TITLE
Fixing filtering by rating

### DIFF
--- a/backend/src/main/java/com/Revature/RevStay/services/SearchFilterService.java
+++ b/backend/src/main/java/com/Revature/RevStay/services/SearchFilterService.java
@@ -29,10 +29,13 @@ public class SearchFilterService {
                 .and(HotelFilterSpecification.hasState(state))
                 .and(HotelFilterSpecification.hasMinPrice(minPrice))
                 .and(HotelFilterSpecification.hasMaxPrice(maxPrice))
-                .and(HotelFilterSpecification.hasAmenities(amenities))
-                .and(HotelFilterSpecification.hasMinRating(minRating));
+                .and(HotelFilterSpecification.hasAmenities(amenities));
 
-        return searchFilterRepository.findAll(spec);
+        List<Hotel> results = searchFilterRepository.findAll(spec);
+        if (minRating != null) {
+            results.removeIf(hotel -> hotel.getRating() < minRating);
+        }
+        return results;
     }
 
     public List<Hotel> findHotelsByPriceRange(Double minPrice, Double maxPrice) {


### PR DESCRIPTION
Since rating is a computed field, it wouldn't be possible to filter by rating on the database. Instead, this retrieves all matching hotels first, then filters those hotels by their computed rating fields.